### PR TITLE
feat: modify score calculation algorithm

### DIFF
--- a/pkg/util/score_util.go
+++ b/pkg/util/score_util.go
@@ -2,10 +2,12 @@ package util
 
 import (
 	"errors"
-	"strconv"
 )
 
 func CalculateScores(config *JudgeConfig) error {
+	if config.Score <= 0 {
+		return errors.New("problem score should be positive")
+	}
 	switch config.Judge.JudgeType {
 	case "classic":
 		switch config.Task.TaskType {
@@ -14,68 +16,87 @@ func CalculateScores(config *JudgeConfig) error {
 			if count > config.Score {
 				return errors.New("the number of cases is larger than score")
 			}
+			if count == 0 {
+				return errors.New("the number of cases is zero")
+			}
 			restScore := config.Score
+			zeroScoreSum := int16(0)
 			for _, c := range config.Task.Cases {
 				restScore -= c.Score
-			}
-			if restScore == 0 {
-				return nil
-			} else if restScore < 0 {
-				return errors.New("the sum of subScore(" + strconv.Itoa(int(config.Score-restScore)) + ") is larger than score(" + strconv.Itoa(int(config.Score)) + ")")
-			} else if count > restScore {
-
-			}
-
-			base := restScore / count
-			start := int(count - restScore%count)
-			for i, c := range config.Task.Cases {
-				score := c.Score + base
-				if i >= start {
-					score++
+				if c.Score == 0 {
+					zeroScoreSum++
 				}
-				config.Task.Cases[i].Score = score
+			}
+			if restScore == 0 && zeroScoreSum == 0 {
+				return nil
+			} else if (restScore == 0 && zeroScoreSum > 0) || restScore < 0 ||
+				(restScore > 0 && zeroScoreSum > 0 && restScore < zeroScoreSum) {
+				for i := range config.Task.Cases {
+					config.Task.Cases[i].Score = 0
+				}
+				restScore = config.Score
+				zeroScoreSum = int16(len(config.Task.Cases))
+			} else if restScore > 0 && zeroScoreSum == 0 {
+				base := restScore / count
+				start := int(count - restScore%count)
+				for i, c := range config.Task.Cases {
+					score := c.Score + base
+					if i >= start {
+						score++
+					}
+					config.Task.Cases[i].Score = score
+				}
+				return nil
+			}
+			for i, c := range config.Task.Cases {
+				if c.Score == 0 {
+					config.Task.Cases[i].Score = restScore / zeroScoreSum
+					restScore -= config.Task.Cases[i].Score
+					zeroScoreSum--
+				}
 			}
 			return nil
 		case "subtasks":
+			if len(config.Task.Subtasks) == 0 {
+				return errors.New("the number of subtasks is zero")
+			}
+			if config.Score < int16(len(config.Task.Subtasks)) {
+				return errors.New("the number of subtasks is larger than score")
+			}
 			sum := config.Score
 			var num int16 = 0
 			for _, sub := range config.Task.Subtasks {
 				if sub.Score == 0 {
 					num += 1
-				} else {
-					sum -= sub.Score
 				}
+				sum -= sub.Score
 			}
-			if sum < 0 {
-				return errors.New("the restScore of subScore(" + strconv.Itoa(int(config.Score-sum)) + ") is larger than sumScore(" + strconv.Itoa(int(config.Score)) + ")")
+			if sum == 0 && num == 0 {
+				return nil
+			} else if (sum == 0 && num > 0) || sum < 0 || (sum > 0 && num > 0 && sum < num) {
+				for i := range config.Task.Subtasks {
+					config.Task.Subtasks[i].Score = 0
+				}
+				sum = config.Score
+				num = int16(len(config.Task.Subtasks))
+			} else if sum > 0 && num == 0 {
+				num = int16(len(config.Task.Subtasks))
+				base := sum / num
+				start := int(num - sum%num)
+				for i, sub := range config.Task.Subtasks {
+					score := sub.Score + base
+					if i >= start {
+						score++
+					}
+					config.Task.Subtasks[i].Score = score
+				}
+				return nil
 			}
-			if num > sum {
-				return errors.New("the number of subScore(" + strconv.Itoa(int(num)) + ") is larger than sumScore(" + strconv.Itoa(int(config.Score)) + ")")
-			}
-
-			avg := sum / num
-			remainder := sum % num
-			for i := range config.Task.Subtasks {
-				sub := &config.Task.Subtasks[i]
+			for i, sub := range config.Task.Subtasks {
 				if sub.Score == 0 {
+					config.Task.Subtasks[i].Score = sum / num
+					sum -= config.Task.Subtasks[i].Score
 					num--
-					sub.Score = avg
-					if num < remainder {
-						sub.Score++
-					}
-				}
-				caseLen := int16(len(sub.Cases))
-				subAvg := sub.Score / caseLen
-				subRemainder := sub.Score % caseLen
-				for j := range sub.Cases {
-					c := &sub.Cases[j]
-					if c.Score == 0 {
-						caseLen--
-						c.Score = subAvg
-						if caseLen < subRemainder {
-							c.Score++
-						}
-					}
 				}
 			}
 			return nil

--- a/pkg/util/score_util_test.go
+++ b/pkg/util/score_util_test.go
@@ -2,7 +2,7 @@ package util
 
 import "testing"
 
-func TestCalculateScores(t *testing.T) {
+func TestCalculateSimpleScores(t *testing.T) {
 	type args struct {
 		config *JudgeConfig
 	}
@@ -13,7 +13,7 @@ func TestCalculateScores(t *testing.T) {
 		wantRes []int16
 	}{
 		{
-			name: "Test CalculateScores 1",
+			name: "Test CalculateSimpleScores 1",
 			args: args{
 				config: &JudgeConfig{
 					Judge: Judge{
@@ -40,7 +40,7 @@ func TestCalculateScores(t *testing.T) {
 			wantRes: []int16{30, 40, 30},
 		},
 		{
-			name: "Test CalculateScores 2",
+			name: "Test CalculateSimpleScores 2",
 			args: args{
 				config: &JudgeConfig{
 					Judge: Judge{
@@ -63,11 +63,11 @@ func TestCalculateScores(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
-			wantRes: []int16{10, 90, 10},
+			wantErr: false,
+			wantRes: []int16{33, 33, 34},
 		},
 		{
-			name: "Test CalculateScores 3",
+			name: "Test CalculateSimpleScores 3",
 			args: args{
 				config: &JudgeConfig{
 					Judge: Judge{
@@ -93,6 +93,125 @@ func TestCalculateScores(t *testing.T) {
 			wantErr: false,
 			wantRes: []int16{23, 33, 44},
 		},
+		{
+			name: "Test CalculateSimpleScores 4",
+			args: args{
+				config: &JudgeConfig{
+					Judge: Judge{
+						JudgeType: "classic",
+					},
+					Score: 100,
+					Task: Task{
+						TaskType: "simple",
+						Cases: []Cases{
+							{
+								Score: 0,
+							},
+							{
+								Score: 0,
+							},
+							{
+								Score: 40,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantRes: []int16{30, 30, 40},
+		},
+		{
+			name: "Test CalculateSimpleScores 5",
+			args: args{
+				config: &JudgeConfig{
+					Judge: Judge{
+						JudgeType: "classic",
+					},
+					Score: 100,
+					Task: Task{
+						TaskType: "simple",
+						Cases:    []Cases{},
+					},
+				},
+			},
+			wantErr: true,
+			wantRes: []int16{},
+		},
+		{
+			name: "Test CalculateSimpleScores 6",
+			args: args{
+				config: &JudgeConfig{
+					Judge: Judge{
+						JudgeType: "classic",
+					},
+					Score: 0,
+					Task: Task{
+						TaskType: "simple",
+						Cases: []Cases{
+							{
+								Score: 20,
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			wantRes: []int16{20},
+		},
+		{
+			name: "Test CalculateSimpleScores 7",
+			args: args{
+				config: &JudgeConfig{
+					Judge: Judge{
+						JudgeType: "classic",
+					},
+					Score: 2,
+					Task: Task{
+						TaskType: "simple",
+						Cases: []Cases{
+							{
+								Score: 20,
+							},
+							{
+								Score: 30,
+							},
+							{
+								Score: 40,
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			wantRes: []int16{20, 30, 40},
+		},
+		{
+			name: "Test CalculateSimpleScores 8",
+			args: args{
+				config: &JudgeConfig{
+					Judge: Judge{
+						JudgeType: "classic",
+					},
+					Score: 100,
+					Task: Task{
+						TaskType: "simple",
+						Cases: []Cases{
+							{
+								Score: 0,
+							},
+							{
+								Score: 0,
+							},
+							{
+								Score: 99,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantRes: []int16{33, 33, 34},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -106,4 +225,234 @@ func TestCalculateScores(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCalculateSubtaskScores(t *testing.T) {
+	type args struct {
+		config *JudgeConfig
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		wantRes []int16
+	}{
+		{
+			name: "Test CalculateSubtaskScores 1",
+			args: args{
+				config: &JudgeConfig{
+					Judge: Judge{
+						JudgeType: "classic",
+					},
+					Score: 100,
+					Task: Task{
+						TaskType: "subtasks",
+						Subtasks: []Subtasks{
+							{
+								Score: 30,
+							},
+							{
+								Score: 40,
+							},
+							{
+								Score: 29,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantRes: []int16{30, 40, 30},
+		},
+		{
+			name: "Test CalculateSubtaskScores 2",
+			args: args{
+				config: &JudgeConfig{
+					Judge: Judge{
+						JudgeType: "classic",
+					},
+					Score: 100,
+					Task: Task{
+						TaskType: "subtasks",
+						Subtasks: []Subtasks{
+							{
+								Score: 10,
+							},
+							{
+								Score: 90,
+							},
+							{
+								Score: 10,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantRes: []int16{33, 33, 34},
+		},
+		{
+			name: "Test CalculateSubtaskScores 3",
+			args: args{
+				config: &JudgeConfig{
+					Judge: Judge{
+						JudgeType: "classic",
+					},
+					Score: 100,
+					Task: Task{
+						TaskType: "subtasks",
+						Subtasks: []Subtasks{
+							{
+								Score: 20,
+							},
+							{
+								Score: 30,
+							},
+							{
+								Score: 40,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantRes: []int16{23, 33, 44},
+		},
+		{
+			name: "Test CalculateSubtaskScores 4",
+			args: args{
+				config: &JudgeConfig{
+					Judge: Judge{
+						JudgeType: "classic",
+					},
+					Score: 100,
+					Task: Task{
+						TaskType: "subtasks",
+						Subtasks: []Subtasks{
+							{
+								Score: 0,
+							},
+							{
+								Score: 0,
+							},
+							{
+								Score: 40,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantRes: []int16{30, 30, 40},
+		},
+		{
+			name: "Test CalculateSubtaskScores 5",
+			args: args{
+				config: &JudgeConfig{
+					Judge: Judge{
+						JudgeType: "classic",
+					},
+					Score: 100,
+					Task: Task{
+						TaskType: "subtasks",
+						Subtasks: []Subtasks{},
+					},
+				},
+			},
+			wantErr: true,
+			wantRes: []int16{},
+		},
+		{
+			name: "Test CalculateSubtaskScores 6",
+			args: args{
+				config: &JudgeConfig{
+					Judge: Judge{
+						JudgeType: "classic",
+					},
+					Score: 0,
+					Task: Task{
+						TaskType: "subtasks",
+						Subtasks: []Subtasks{
+							{
+								Score: 20,
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			wantRes: []int16{20},
+		},
+		{
+			name: "Test CalculateSubtaskScores 7",
+			args: args{
+				config: &JudgeConfig{
+					Judge: Judge{
+						JudgeType: "classic",
+					},
+					Score: 2,
+					Task: Task{
+						TaskType: "subtasks",
+						Subtasks: []Subtasks{
+							{
+								Score: 20,
+							},
+							{
+								Score: 30,
+							},
+							{
+								Score: 40,
+							},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			wantRes: []int16{20, 30, 40},
+		},
+		{
+			name: "Test CalculateSubtaskScores 8",
+			args: args{
+				config: &JudgeConfig{
+					Judge: Judge{
+						JudgeType: "classic",
+					},
+					Score: 100,
+					Task: Task{
+						TaskType: "subtasks",
+						Subtasks: []Subtasks{
+							{
+								Score: 0,
+							},
+							{
+								Score: 0,
+							},
+							{
+								Score: 99,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantRes: []int16{33, 33, 34},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := CalculateScores(tt.args.config); (err != nil) != tt.wantErr {
+				t.Errorf("CalculateScores() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			for i, c := range tt.args.config.Task.Subtasks {
+				if c.Score != tt.wantRes[i] {
+					t.Errorf("CalculateScores() = %v, want %v", c.Score, tt.wantRes[i])
+				}
+			}
+		})
+	}
+}
+
+func TestCalculateScores(t *testing.T) {
+	TestCalculateSimpleScores(t)
+	TestCalculateSubtaskScores(t)
 }


### PR DESCRIPTION
An improvement on #89 @love98ooo 

For cases and subtask (classic-simple/subtasks):
Using cases as an example, subtasks have the same method
1. If total score = sum(cases) and no case with a score of 0, no calculations are required
2. If total score = sum(cases) and at least one case has a score of 0, recalculate all scores
3. If total score < sum(cases), recalculate all scores
4. If total score > sum(cases), at least one case has a score of 0, the number of unassigned points is greater than the number of cases's, average the remaining scores to the case with score 0
5. If total score > sum(cases), at least one case has a score of 0, the number of unassigned points is less than the number of cases's, recalculate all scores
6. If total score > sum(cases) and no case with a score of 0, distribute the remaining scores to all cases.

Since subtask's type is min, the subtask will be scored only when all cases are passed at the present stage, we have no need to calculate the score of cases in subtask. But the type of max and sum are needed as a feature.